### PR TITLE
PDOK-4774 Write output straight to zip files

### DIFF
--- a/src/gml_to_featured/api.clj
+++ b/src/gml_to_featured/api.clj
@@ -6,10 +6,9 @@
             [ring.util.response :as r]
             [ring.middleware.json :refer :all]
             [ring.middleware.defaults :refer :all]
-            [clj-time [core :as t] [local :as tl]]
+            [clj-time [local :as tl]]
             [compojure.core :refer :all]
             [compojure.route :as route]
-            [schema.core :as s]
             [clj-http.client :as http]
             [clojure.tools.logging :as log]
             [clojure.string :as str]
@@ -20,6 +19,7 @@
             [clojure.java.io :as io])
   (:gen-class)
   (:import (clojure.lang PersistentQueue)
+           (com.fasterxml.jackson.core JsonGenerator)
            (java.io File FileInputStream)
            (java.net URI URISyntaxException)
            (java.util.zip ZipEntry ZipFile ZipOutputStream)
@@ -27,7 +27,7 @@
 
 (extend-protocol cheshire.generate/JSONable
   DateTime
-  (to-json [t jg] (.writeString jg (str t))))
+  (to-json [t, ^JsonGenerator jg] (.writeString jg (str t))))
 
 (defn- translate-file-from-stream [reader, dataset, mapping, validity, ^String json-filename]
   "Read from reader, xml2json translate the content"

--- a/src/gml_to_featured/config.clj
+++ b/src/gml_to_featured/config.clj
@@ -3,7 +3,9 @@
             [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [environ.core :as environ]))
+            [environ.core :as environ])
+  (:import (java.io Reader)
+           (java.util Properties)))
 
 (Thread/setDefaultUncaughtExceptionHandler
   (reify Thread$UncaughtExceptionHandler
@@ -18,8 +20,8 @@
       (keyword)))
 
 (defn load-props [resource-file]
-  (with-open [^java.io.Reader reader (io/reader (io/resource resource-file))]
-    (let [props (java.util.Properties.)
+  (with-open [^Reader reader (io/reader (io/resource resource-file))]
+    (let [props (Properties.)
           _ (.load props reader)]
       (into {} (for [[k v] props
                      ;; no mustaches, for local use

--- a/src/gml_to_featured/filesystem.clj
+++ b/src/gml_to_featured/filesystem.clj
@@ -3,10 +3,11 @@
             [gml-to-featured.config :refer [env] :as config]
             [clj-time.core :as time]
             clj-time.coerce)
-  (:import (java.util UUID)))
+  (:import (java.io File)
+           (java.util UUID)))
 
 (def resultstore
-  (let [path config/store-dir]
+  (let [^File path config/store-dir]
     (when-not (.exists path) (.mkdirs path))
     path))
 

--- a/src/gml_to_featured/filesystem.clj
+++ b/src/gml_to_featured/filesystem.clj
@@ -31,8 +31,11 @@
 (defn uuid []
   (str (UUID/randomUUID)))
 
+(defn json-filename [original-filename]
+  (str (uuid) "-" original-filename ".json"))
+
 (defn create-target-file [name]
-  (io/file resultstore (str (uuid) "-" name ".json")))
+  (io/file resultstore (str name ".zip")))
 
 (defn get-file [name]
   (let [file (io/file resultstore name)]

--- a/src/gml_to_featured/runner.clj
+++ b/src/gml_to_featured/runner.clj
@@ -9,7 +9,8 @@
             [clojure.zip :as z]
             [clj-time.format :as f])
   (:gen-class)
-  (:import (java.util.zip ZipOutputStream)
+  (:import (java.io InputStream)
+           (java.util.zip ZipOutputStream)
            (javax.xml.stream.events XMLEvent)))
 
 (def ^:dynamic *sequence-selector* identity)
@@ -70,7 +71,7 @@
           (log/info "Processed " @counter))
         obj)))
 
-  (defn process-stream [stream]
+  (defn process-stream [^InputStream stream]
     (let [log-progress (progress-logger)
           sequence-selector (if (nil? *sequence-selector*) identity *sequence-selector*)]
       (->> stream
@@ -176,7 +177,7 @@
   (defn implementation-version []
     (if-let [version (System/getProperty "gml-to-featured.version")]
       version
-      (-> ^java.lang.Class (eval 'gml_to_featured.runner) .getPackage .getImplementationVersion)))
+      (-> ^Class (eval 'gml_to_featured.runner) .getPackage .getImplementationVersion)))
 
   (defn usage [options-summary]
     (->> ["This program converts xml to featured-ready json. The conversion is done using the provided mappingconfig(uration) specified in edn."

--- a/src/gml_to_featured/runner.clj
+++ b/src/gml_to_featured/runner.clj
@@ -9,8 +9,7 @@
             [clojure.zip :as z]
             [clj-time.format :as f])
   (:gen-class)
-  (:import (java.io InputStream)
-           (java.util.zip ZipOutputStream)
+  (:import (java.io InputStream OutputStream)
            (javax.xml.stream.events XMLEvent)))
 
 (def ^:dynamic *sequence-selector* identity)
@@ -84,7 +83,7 @@
            (map log-progress)
            (filter #(not= unknown %)))))
 
-  (defn process [reader, ^ZipOutputStream writer, dataset-name, validity]
+  (defn process [reader, ^OutputStream writer, dataset-name, validity]
     (let [first? (ref true)
           write-fn (fn [^String str] (.write writer (.getBytes str)))]
       (write-fn (str "{\"dataset\":\"" dataset-name "\",\n\"features\":["))

--- a/src/gml_to_featured/xml.clj
+++ b/src/gml_to_featured/xml.clj
@@ -1,12 +1,9 @@
 (ns gml-to-featured.xml
-  (:require [clojure.data.xml :as xml]
-            [clojure.zip :as zip]
+  (:require [clojure.zip :as zip]
             [clojure.data.zip :as zf])
   (:import [java.io ByteArrayOutputStream]
-           [javax.xml.namespace QName]
-           [javax.xml.stream XMLInputFactory XMLOutputFactory XMLEventReader
-            XMLStreamConstants XMLEventWriter]
-           [javax.xml.stream.events XMLEvent EndElement]))
+           [javax.xml.stream XMLEventReader XMLEventWriter XMLInputFactory XMLOutputFactory XMLStreamConstants]
+           [javax.xml.stream.events Attribute EndElement XMLEvent]))
 
 (def ^XMLInputFactory input-factory (XMLInputFactory/newFactory))
 
@@ -26,7 +23,7 @@
 
 (defn attr-with-name [loc attrname]
   "Get the attribute with attrname. Alternative implementation for attr"
-  (some #(if (= (.getLocalPart (.getName %)) attrname) (.getValue %)) (:attrs (zip/node loc))))
+  (some (fn [^Attribute a] (if (= (.getLocalPart (.getName a)) attrname) (.getValue a))) (:attrs (zip/node loc))))
 
 (defn id-attr [loc]
   (attr-with-name loc "id"))

--- a/src/gml_to_featured/zip.clj
+++ b/src/gml_to_featured/zip.clj
@@ -1,19 +1,7 @@
 (ns gml-to-featured.zip
-  (:require [clojure.java.io :as io]
-            [clojure.tools.logging :as log])
-  (:import (java.util.zip ZipOutputStream ZipFile ZipEntry)))
+  (:import (java.util.zip ZipEntry ZipFile)))
 
 (defn xml-entries [^ZipFile zipfile]
   (filter (fn [e] (and #(not (.isDirectory e))
                        (or (.endsWith (.getName e) "xml")
                            (.endsWith (.getName e) "gml")))) (enumeration-seq (.entries zipfile))))
-
-(defn zip-file [uncompressed-file]
-  "Return zip-file location with zipped content of uncompressed-file"
-  (let [compressed-file (io/file (.getParent uncompressed-file) (str (.getName uncompressed-file) ".zip"))]
-    (log/debug "Compressing file" (.getName uncompressed-file))
-    (with-open [zip (ZipOutputStream. (io/output-stream compressed-file))]
-      (.putNextEntry zip (ZipEntry. (.getName uncompressed-file)))
-      (io/copy uncompressed-file zip)
-      (.closeEntry zip)
-      compressed-file)))

--- a/src/gml_to_featured/zip.clj
+++ b/src/gml_to_featured/zip.clj
@@ -2,6 +2,6 @@
   (:import (java.util.zip ZipEntry ZipFile)))
 
 (defn xml-entries [^ZipFile zipfile]
-  (filter (fn [e] (and #(not (.isDirectory e))
-                       (or (.endsWith (.getName e) "xml")
-                           (.endsWith (.getName e) "gml")))) (enumeration-seq (.entries zipfile))))
+  (filter (fn [^ZipEntry e] (and #(not (.isDirectory e))
+                                 (or (.endsWith (.getName e) "xml")
+                                     (.endsWith (.getName e) "gml")))) (enumeration-seq (.entries zipfile))))


### PR DESCRIPTION
GML-to-Featured wastes a lot of resources by first creating an output JSON file for every input file and only zipping these after all conversions are completed. This PR refactors this process to use a ZipOutputStream, so no intermediate uncompressed files are created.

Two smaller fixes are included as well:
- DM sends the original filename of the update data in the HTTP header. When found, this information is now used instead of the filename in the download URL.
- Type hints were added to all objects on which native Java functions are called, to prevent Clojure from using reflection at runtime. This removes most warnings in the IDE and should also increase performance.