### PR TITLE
FID attribute toegevoegd

### DIFF
--- a/src/gml_to_featured/code.clj
+++ b/src/gml_to_featured/code.clj
@@ -15,6 +15,7 @@
 
 (def key->fn {:s/tag `[tag]
               :s/id-attr `[id-attr]
+              :s/fid-attr `[fid-attr]
               :s/inner-gml `[inner-gml]
               :s/boolean `[text boolean (function "boolean")]
               :s/int `[text #(. Integer parseInt %) (function "int")]

--- a/src/gml_to_featured/xml.clj
+++ b/src/gml_to_featured/xml.clj
@@ -28,6 +28,9 @@
 (defn id-attr [loc]
   (attr-with-name loc "id"))
 
+(defn fid-attr [loc]
+  (attr-with-name loc "fid"))
+
 (defn attr
   "Returns the xml attribute named attrname, of the xml node at location loc."
   ([attrname]     (fn [loc] (attr loc attrname)))


### PR DESCRIPTION
Mogelijk gemaakt dat een gml file met FID attribute ipv een ID attribute ook uitgelezen kan worden. 

Het zou mooier zijn als je elk attribute kan uitlezen ongeacht de naam van het attribute, hier ga ik naar kijken.